### PR TITLE
fix for disabling scheduled dates conditionally

### DIFF
--- a/src/components/voyage/PostVoyageForm.tsx
+++ b/src/components/voyage/PostVoyageForm.tsx
@@ -139,7 +139,7 @@ const PostVoaygeForm = ({ onSubmit }: PostVoaygeFormProps) => {
                             <FormControl>
                                 <DatePickerSingle
                                     {...field}
-                                    disabled={{ before: form.getValues().scheduledArrival ?? today }}
+                                    disabled={{ before: form.getValues().scheduledArrival, after: new Date() }}
                                     required />
                             </FormControl>
                             <FormMessage />
@@ -155,7 +155,7 @@ const PostVoaygeForm = ({ onSubmit }: PostVoaygeFormProps) => {
                             <FormControl>
                                 <DatePickerSingle
                                     {...field}
-                                    disabled={{ before: form.getValues().scheduledDeparture ?? today }}
+                                    disabled={{ after: form.getValues().scheduledDeparture ?? new Date() }}
                                     required />
                             </FormControl>
                             <FormMessage />

--- a/src/components/voyage/PostVoyageForm.tsx
+++ b/src/components/voyage/PostVoyageForm.tsx
@@ -139,7 +139,7 @@ const PostVoaygeForm = ({ onSubmit }: PostVoaygeFormProps) => {
                             <FormControl>
                                 <DatePickerSingle
                                     {...field}
-                                    disabled={{ before: form.getValues().scheduledArrival, after: new Date() }}
+                                    disabled={{ after: form.getValues().scheduledArrival, before: today }}
                                     required />
                             </FormControl>
                             <FormMessage />
@@ -155,7 +155,7 @@ const PostVoaygeForm = ({ onSubmit }: PostVoaygeFormProps) => {
                             <FormControl>
                                 <DatePickerSingle
                                     {...field}
-                                    disabled={{ after: form.getValues().scheduledDeparture ?? new Date() }}
+                                    disabled={{ after: form.getValues().scheduledDeparture ?? today }}
                                     required />
                             </FormControl>
                             <FormMessage />


### PR DESCRIPTION
Introduced a bug fix where it was possible to select arrival date before departure. 
Implemented with an usage of react-day-picker component property `disabled`